### PR TITLE
Declare ext-mcrypt as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
+        "ext-mcrypt": "*",
         "symfony/framework-bundle": "~2.1"
     },
     "autoload": {


### PR DESCRIPTION
Since this bundle relies on `mcrypt_…` functions, it should declare a dependency on the extension explicitly - it's not built by default and will be removed in a future PHP 7.x release, so a "composer install" should error if the extension is not there.

As a side-effect, some platforms, such as Heroku, can use the declaration to automatically enable the extension if necessary.