### PR TITLE
fix: DependencyInjection\NzoEncryptorExtension load method native return type

### DIFF
--- a/DependencyInjection/NzoEncryptorExtension.php
+++ b/DependencyInjection/NzoEncryptorExtension.php
@@ -20,7 +20,7 @@ class NzoEncryptorExtension extends Extension
 {
     const MAX_LENGTH = 100;
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future.