### PR TITLE
Fixing depreceated return of methods LoadAnnotationService::process and NzoUrIEncryptorBundle::build

### DIFF
--- a/DependencyInjection/Compiler/LoadAnnotationService.php
+++ b/DependencyInjection/Compiler/LoadAnnotationService.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class LoadAnnotationService implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $container
             ->register('nzo.annotation_resolver', AnnotationResolver::class)

--- a/NzoUrlEncryptorBundle.php
+++ b/NzoUrlEncryptorBundle.php
@@ -24,7 +24,7 @@ class NzoUrlEncryptorBundle extends Bundle
         return new NzoEncryptorExtension();
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new LoadAnnotationService());
     }


### PR DESCRIPTION
With the latest Symfony versions, we have some depreceated reported in logs : 

| deprecation | Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Nzo\UrlEncryptorBundle\DependencyInjection\Compiler\LoadAnnotationService" now to avoid errors or add an explicit @return annotation to suppress this message. |
|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| deprecation | User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Nzo\UrlEncryptorBundle\NzoUrlEncryptorBundle" now to avoid errors or add an explicit @return annotation to suppress this message.                                            |

To fix this, adding the return type `void` to the following methods fix the issues : 

- `Nzo\UrlEncryptorBundle\DependencyInjection\Compiler\LoadAnnotationService::process`
- `Nzo\UrlEncryptorBundle\NzoUrlEncryptorBundle::build`

Because of the required php version `^7.1.3` of the bundle and this PR similiraty with https://github.com/nayzo/NzoUrlEncryptorBundle/pull/67 it shoud be harmless for all the users of the bundle.