### PR TITLE
Fix named parameters that doesn't work

### DIFF
--- a/Annotations/AnnotationResolver.php
+++ b/Annotations/AnnotationResolver.php
@@ -53,7 +53,7 @@ class AnnotationResolver
 
         foreach ($annotations as $configuration) {
             // handle php8 attribute
-            if (class_exists('ReflectionAttribute')) {
+            if ($configuration instanceof \ReflectionAttribute) {
                 $configuration = $this->handleReflectionAttribute($configuration);
             }
 
@@ -94,11 +94,8 @@ class AnnotationResolver
     {
         if ($configuration instanceof \ReflectionAttribute
             && \in_array($configuration->getName(), [ParamEncryptor::class, ParamDecryptor::class], true)) {
-            $class = $configuration->getName();
-            $arguments = $configuration->getArguments();
-            $params = \is_array($arguments) && [] !== $arguments && \is_array($arguments[0]) ? $arguments[0] : [];
 
-            return new $class($params);
+            return $configuration->newInstance();
         }
 
         return $configuration;

--- a/Annotations/ParamDecryptor.php
+++ b/Annotations/ParamDecryptor.php
@@ -22,15 +22,17 @@ class ParamDecryptor
 
     public function __construct(array $params = [])
     {
-        $this->params = $params;
+        if (isset($params['value']) && \is_array($params['value'])) {
+            $this->params = $params['value'];
+        } elseif (isset($params['params']) && \is_array($params['params'])) {
+            $this->params = $params['params'];
+        } else {
+            $this->params = $params;
+        }
     }
 
     public function getParams(): array
     {
-        if (isset($this->params['value']) && \is_array($this->params['value'])) {
-            return $this->params['value'];
-        }
-
         return $this->params;
     }
 }

--- a/Annotations/ParamEncryptor.php
+++ b/Annotations/ParamEncryptor.php
@@ -22,15 +22,17 @@ class ParamEncryptor
 
     public function __construct(array $params = [])
     {
-        $this->params = $params;
+        if (isset($params['value']) && \is_array($params['value'])) {
+            $this->params = $params['value'];
+        } elseif (isset($params['params']) && \is_array($params['params'])) {
+            $this->params = $params['params'];
+        } else {
+            $this->params = $params;
+        }
     }
 
     public function getParams(): array
     {
-        if (isset($this->params['value']) && \is_array($this->params['value'])) {
-            return $this->params['value'];
-        }
-
         return $this->params;
     }
 }

--- a/Tests/Annotations/AnnotationResolverTest.php
+++ b/Tests/Annotations/AnnotationResolverTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Nzo\UrlEncryptorBundle\Tests\Annotations;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Nzo\UrlEncryptorBundle\Annotations\AnnotationResolver;
+use Nzo\UrlEncryptorBundle\Encryptor\Encryptor;
+use Nzo\UrlEncryptorBundle\Tests\Annotations\Fixtures\DummyController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class AnnotationResolverTest extends TestCase
+{
+    public function provideDecryptOnKernelController(): array
+    {
+        return [
+            ['decryptWithAttribute', true],
+            ['decryptWithAttributeAndNamedProperty', true],
+            ['decryptWithAnnotation', false],
+            ['decryptWithAnnotationAndNamedProperty', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDecryptOnKernelController
+     */
+    public function testDecryptOnKernelController(string $action, bool $needsPhp8): void
+    {
+        if ($needsPhp8 && PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('At least PHP 8 is needed for this test');
+        }
+
+        $encryptor = new Encryptor('foo', 'aes-256-ctr', true, true, true);
+        $encryptor->setSecretIv(null);
+
+        $request = Request::create('/');
+        $request->attributes->set('id', $encryptor->encrypt('12'));
+
+        $controllerEvent = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new DummyController(), $action],
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $sut = new AnnotationResolver($encryptor, new AnnotationReader());
+        $sut->onKernelController($controllerEvent);
+
+        $this->assertSame('12', $request->attributes->get('id'));
+    }
+
+    public function provideEncryptOnKernelController(): array
+    {
+        return [
+            ['encryptWithAttribute', true],
+            ['encryptWithAttributeAndNamedProperty', true],
+            ['encryptWithAnnotation', false],
+            ['encryptWithAnnotationAndNamedProperty', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEncryptOnKernelController
+     */
+    public function testEncryptOnKernelController(string $action, bool $needsPhp8): void
+    {
+        if ($needsPhp8 && PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('At least PHP 8 is needed for this test');
+        }
+
+        $encryptor = new Encryptor('foo', 'aes-256-ctr', true, true, true);
+        $encryptor->setSecretIv(null);
+
+        $request = Request::create('/');
+        $request->attributes->set('id', '12');
+
+        $controllerEvent = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new DummyController(), $action],
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $sut = new AnnotationResolver($encryptor, new AnnotationReader());
+        $sut->onKernelController($controllerEvent);
+
+        $this->assertSame($encryptor->encrypt('12'), $request->attributes->get('id'));
+    }
+}

--- a/Tests/Annotations/Fixtures/DummyController.php
+++ b/Tests/Annotations/Fixtures/DummyController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Nzo\UrlEncryptorBundle\Tests\Annotations\Fixtures;
+
+use Nzo\UrlEncryptorBundle\Annotations\ParamDecryptor;
+use Nzo\UrlEncryptorBundle\Annotations\ParamEncryptor;
+use Symfony\Component\HttpFoundation\Response;
+
+class DummyController
+{
+    #[ParamDecryptor(['id'])]
+    public function decryptWithAttribute()
+    {
+    }
+
+    #[ParamDecryptor(params: ['id'])]
+    public function decryptWithAttributeAndNamedProperty()
+    {
+    }
+
+    /**
+     * @ParamDecryptor({"id"})
+     */
+    public function decryptWithAnnotation()
+    {
+    }
+
+    /**
+     * @ParamDecryptor(params={"id"})
+     */
+    public function decryptWithAnnotationAndNamedProperty()
+    {
+    }
+
+    #[ParamEncryptor(['id'])]
+    public function encryptWithAttribute()
+    {
+    }
+
+    #[ParamEncryptor(params: ['id'])]
+    public function encryptWithAttributeAndNamedProperty()
+    {
+    }
+
+    /**
+     * @ParamEncryptor({"id"})
+     */
+    public function encryptWithAnnotation()
+    {
+    }
+
+    /**
+     * @ParamEncryptor(params={"id"})
+     */
+    public function encryptWithAnnotationAndNamedProperty()
+    {
+    }
+}


### PR DESCRIPTION
Named parameters doesn't work for attributes nor annotations:

What is working:

`#[ParamDecrypt(['id'])]` or `@ParamDecrypt({"id"})`

What is not working:

`#[ParamDecrypt(params: ['id'])]` or `@ParamDecrypt(params={"id"})`