### PR TITLE
chore(deps): Make `doctrine/annotations` optional

### DIFF
--- a/Annotations/AnnotationResolver.php
+++ b/Annotations/AnnotationResolver.php
@@ -20,10 +20,7 @@ class AnnotationResolver
     private $decryptor;
     private $reader;
 
-    /**
-     * @param Reader|null $reader
-     */
-    public function __construct(Encryptor $decryptor, $reader)
+    public function __construct(Encryptor $decryptor, ?Reader $reader = null)
     {
         $this->decryptor = $decryptor;
         $this->reader = $reader;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,6 +26,9 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->booleanNode('annotations')
+                    ->defaultNull()
+                ->end()
                 ->scalarNode('secret_key')
                     ->isRequired()
                     ->cannotBeEmpty()

--- a/DependencyInjection/NzoEncryptorExtension.php
+++ b/DependencyInjection/NzoEncryptorExtension.php
@@ -37,6 +37,7 @@ class NzoEncryptorExtension extends Extension
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
 
+        $container->setParameter('nzo_encryptor.annotations', $config['annotations']);
         $container->setParameter('nzo_encryptor.secret_key', $this->cleanKey($config['secret_key']));
         $container->setParameter('nzo_encryptor.secret_iv', $this->cleanKey($config['secret_iv']));
         $container->setParameter('nzo_encryptor.cipher_algorithm', $cipherAlgorithm);

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ return [
 # config/packages/nzo_encryptor.yaml
 
 nzo_encryptor:
+    annotations: false                       # optional, if you want to disable the use of annotations (keep only PHP attributes)
     secret_key: Your_Secret_Encryption_Key   # Required, max length of 100 characters.
     secret_iv:  Your_Secret_Iv               # Required only if "random_pseudo_bytes" is FALSE. Max length of 100 characters.
     cipher_algorithm:                        # optional, default: 'aes-256-ctr'
@@ -64,6 +65,8 @@ nzo_encryptor:
     format_base64_output:                    # optional, default: TRUE, used only when 'base64_encode' is set to TRUE
     random_pseudo_bytes:                     # optional, default: TRUE (generate a random encrypted text output each time => MORE SECURE !)
 ```
+
+**!!! If you set `nzo_encryptor.annotations` to `true`, you must require `composer require doctrine/annotations` in your project.**
 
 ##### * To generate the same cypher text each time: `random_pseudo_bytes: FALSE` (Not Secure)
 ##### * To generate a different cypher text each time: `random_pseudo_bytes: TRUE` (Secure)
@@ -117,8 +120,10 @@ use Nzo\UrlEncryptorBundle\Annotations\ParamEncryptor;
 class MyController
 {
     /**
-    * @ParamDecryptor({"id", "foo"})   OR    #[ParamDecryptor(["id", "foo"])]
+    * @ParamDecryptor({"id", "foo"})
     */
+    // OR
+    #[ParamDecryptor(["id", "foo"])]
     public function decryptionAction($id, $foo)
     {
         // no need to use the decryption service here as the parameters are already decrypted by the annotation service.
@@ -126,8 +131,10 @@ class MyController
     }
 
     /**
-    * @ParamEncryptor({"id", "foo"})   OR    #[ParamEncryptor(["id", "foo"])]
+    * @ParamEncryptor({"id", "foo"})
     */
+    // OR
+    #[ParamEncryptor(["id", "foo"])]
     public function encryptionAction($id, $foo)
     {
         // no need to use the encryption service here as the parameters are already encrypted by the annotation service.

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -19,3 +19,10 @@ services:
             - "@nzo_encryptor"
         tags:
             - { name: twig.extension }
+
+    nzo.annotation_resolver:
+        class: Nzo\UrlEncryptorBundle\Annotations\AnnotationResolver
+        arguments:
+            - '@nzo_encryptor'
+        tags:
+            - {name: 'kernel.event_listener', event: 'kernel.controller', method: 'onKernelController'}

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     "require": {
         "php": ">=7.1.3",
         "ext-openssl": "*",
-        "doctrine/annotations": "^1.7|^2.0",
         "symfony/framework-bundle": "^4.4|^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0|^8.0|^9.0"
+        "phpunit/phpunit": "^7.0|^8.0|^9.0",
+        "doctrine/annotations": "^1.7|^2.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
With PHP attributes, `doctrine/annotations` become non require for this bundle to work. The requirement on this dep is now unnecessary.

Still give the capability to keep it I you wanted to.


PS: This become problematic when trying to update projects that use dependencies that become incompatible with `doctrine/annotations`.